### PR TITLE
Fix error when showing the failed census calls

### DIFF
--- a/app/views/admin/verifications/_failed_census_call.html.erb
+++ b/app/views/admin/verifications/_failed_census_call.html.erb
@@ -1,6 +1,5 @@
 <div>
   <%= humanize_document_type(failed_census_call.document_type) %>
   <%= failed_census_call.document_number %>
-  <%= l(failed_census_call.date_of_birth) %>
-  <%= failed_census_call.postal_code %>
+  <%= failed_census_call.phone_number %>
 </div>

--- a/spec/factories/verifications.rb
+++ b/spec/factories/verifications.rb
@@ -31,8 +31,7 @@ FactoryBot.define do
     user
     document_number
     document_type { 1 }
-    date_of_birth { Date.new(1900, 1, 1) }
-    postal_code { "28000" }
+    phone_number { "6666666666" }
   end
 
   factory :verification_sms, class: "Verification::Sms" do

--- a/spec/system/admin/verifications_spec.rb
+++ b/spec/system/admin/verifications_spec.rb
@@ -40,8 +40,7 @@ describe "Incomplete verifications", :admin do
     within "#user_#{incompletely_verified_user.id}" do
       expect(page).to have_content "DNI"
       expect(page).to have_content failed_census_call.document_number
-      expect(page).to have_content Date.new(1900, 1, 1)
-      expect(page).to have_content "28000"
+      expect(page).to have_content "6666666666"
     end
   end
 


### PR DESCRIPTION
## References

- Error https://errors.democrateam.com/apps/60c99749b2aa29034df29e6a/problems/610ae4beb2aa29034cf2a0fd
- PR https://github.com/sisli-consul/consul/pull/6

## Objectives

Fix error when showing the failed census calls