### PR TITLE
Show delayed job errors on Errbit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ gem "rails", "5.2.4.6"
 gem "acts-as-taggable-on", "~> 6.5.0"
 gem "acts_as_votable", "~> 0.12.1"
 gem "ahoy_matey", "~> 1.6.0"
-gem "airbrake", "~> 5.0"
 gem "ancestry", "~> 3.2.1"
 gem "audited", "~> 4.9.0"
 gem "autoprefixer-rails", "~> 8.2.0"
@@ -62,6 +61,7 @@ gem "view_component", "~> 2.19.1", require: "view_component/engine"
 gem "whenever", "~> 1.0.0", require: false
 gem "wicked_pdf", "~> 2.1.0"
 gem "wkhtmltopdf-binary", "~> 0.12.4"
+gem "airbrake", "~> 5.0"
 
 source "https://rails-assets.org" do
   gem "rails-assets-leaflet"


### PR DESCRIPTION
## References

Airbrake docs https://github.com/airbrake/airbrake#delayedjob

## Objectives

Add Errors from `delayed_job` also in Errbit
According to the documentation adding the line `require 'airbrake/delayed_job'` should work, but it didn't, so we changed the order that gems are loaded so we make sure `delayed_job` is always loaded before `airbrake`.


## Visual Changes
Errors are now being received in Errbit:

![Captura de pantalla 2021-08-05 a las 11 47 53](https://user-images.githubusercontent.com/942995/128292464-1df93867-1bb9-472b-b7be-20da64aaa8f3.png)